### PR TITLE
updated code to correctly check if you're in-game or not using AP Core.

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -64,6 +64,7 @@ namespace MedievilArchipelago
             ulong contents_offset = 0xc;
             return new Dictionary<int, List<ulong>>
             {
+                [0] = [], // main menu
                 [1] = [Addresses.TG_Pickup_CopperShield + contents_offset],
                 [2] = [Addresses.RTG_Pickup_SilverShieldChestAtShop + contents_offset],
                 [3] = [Addresses.CH_Pickup_Club + contents_offset, Addresses.CH_Pickup_CopperShield1stOnHill + contents_offset, Addresses.CH_Pickup_CopperShield2ndOnHill + contents_offset, Addresses.CH_Pickup_CopperShield3rdOnHill + contents_offset],

--- a/Program.cs
+++ b/Program.cs
@@ -121,17 +121,17 @@ catch (Exception ex)
 //};
 
 // wait till you're in-game
-uint currentGameStatus = Memory.ReadUInt(Addresses.InGameCheck);
+//uint currentGameStatus = Memory.ReadUInt(Addresses.InGameCheck);
 
 
-while (currentGameStatus != 0x800f8198) // 0x00 means not in a level
-{
-    currentGameStatus = Memory.ReadUInt(Addresses.InGameCheck);
-    Console.WriteLine($"Waiting to be in-game...");
-    await Task.Delay(5000);
+//while (currentGameStatus != 0x800f8198) // 0x00 means not in a level
+//{
+//    currentGameStatus = Memory.ReadUInt(Addresses.InGameCheck);
+//    Console.WriteLine($"Waiting to be in-game...");
+//    await Task.Delay(5000);
 
 
-}
+//}
 
 
 
@@ -174,6 +174,7 @@ archipelagoClient.Disconnected += (sender, args) => OnDisconnected(sender, args,
 archipelagoClient.ItemReceived += ItemReceived;
 archipelagoClient.MessageReceived += Client_MessageReceived;
 archipelagoClient.LocationCompleted += Client_LocationCompleted;
+archipelagoClient.EnableLocationsCondition = () => isInTheGame();
 
 var cts = new CancellationTokenSource();
 try
@@ -247,6 +248,19 @@ finally
 {
     // Perform any necessary cleanup here
     Console.WriteLine("Shutting down...");
+
+}
+
+bool isInTheGame(){
+    ulong currentGameStatus = Memory.ReadUInt(Addresses.InGameCheck);
+    ulong currentGold = Memory.ReadUInt(Addresses.CurrentGold);
+    ulong currentLevel = Memory.ReadUInt(Addresses.CurrentLevel);
+
+    if(currentGameStatus != 0x800f8198 || currentGold == 0x82a4 || currentLevel == 0x0000)
+    {
+        return false;
+    }
+    return true;
 
 }
 


### PR DESCRIPTION
Rather than a while loop blocking it at the start, you can log into archipelago at any point and checks will stay. 